### PR TITLE
Use os.UserHomeDir()

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.11.5
+      - image: circleci/golang:1.12.0
     working_directory: /go/src/github.com/student-kyushu/frau
     environment:
       GO111MODULE: "on"
@@ -27,7 +27,7 @@ jobs:
             - "/go/pkg/mod"
   deploy:
     docker:
-      - image: circleci/golang:1.11.5
+      - image: circleci/golang:1.12.0
     working_directory: /go/src/github.com/student-kyushu/frau
     environment:
       GO111MODULE: "on"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.11.5
+  - 1.12.0
 
 cache:
   directories:

--- a/setting/home_dir.go
+++ b/setting/home_dir.go
@@ -1,11 +1,9 @@
 package setting
 
 import (
-	"errors"
 	"log"
 	"os"
 	"path/filepath"
-	"runtime"
 )
 
 const XdgConfigHomeEnvKey = "XDG_CONFIG_HOME"
@@ -34,7 +32,7 @@ func getXdgConfigHome() string {
 	if v == "" {
 		log.Println("info: try to use `~/.config` as $XDG_CONFIG_HOME")
 
-		home, err := getHome()
+		home, err := os.UserHomeDir()
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -53,22 +51,4 @@ func getXdgConfigHome() string {
 	}
 
 	return path
-}
-
-func getHome() (string, error) {
-	isWin := runtime.GOOS == "windows"
-	var HomeKey string
-	if isWin {
-		HomeKey = "USERPROFILE"
-	} else {
-		HomeKey = "HOME"
-	}
-
-	h := os.Getenv(HomeKey)
-	home, err := filepath.Abs(h)
-	if home == "" {
-		err = errors.New("not found $" + HomeKey)
-	}
-
-	return home, err
 }


### PR DESCRIPTION
`os.UserHomeDir()` is added in Go 1.12. ref. https://golang.org/doc/go1.12#os
I think it's good to reduce unnecessary functions but this change limits Go version.
(I tested on Ubuntu 18.04.2, it worked well.)