### PR TITLE
fix: Make name inline

### DIFF
--- a/epic/accept_changeset.go
+++ b/epic/accept_changeset.go
@@ -207,7 +207,7 @@ func commentApprovedSha(
 				list = append(list, fmt.Sprintf("`%v`", name))
 			}
 			if containsMe, index := contains(list, "`me`"); containsMe {
-				list[index] = sender
+				list[index] = fmt.Sprintf("`%v`", sender)
 			}
 			reviewers = strings.Join(list, ", ")
 		}


### PR DESCRIPTION
I noticed my name wasn't inline seeing [this comment](https://github.com/student-kyushu/frau/pull/56#issuecomment-471281315). Yes, I forgot fencing name with backticks. 😅

r? @ghost